### PR TITLE
Add FastAPI backend prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# chores
+# Chores
+
+Prototype backend for the Chore Management System described in `docs/design.md`. It exposes a FastAPI application with basic endpoints for managing chores, assignments, rewards, and point totals.
+
+## Running
+```
+uvicorn backend.main:app --reload
+```
+
+## Tests
+```
+pytest
+```

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+from fastapi import FastAPI
+from typing import List
+from .models import User, Chore, Assignment, Reward, PointLedgerEntry
+from .storage import DB
+
+app = FastAPI(title="Chore Management System")
+
+
+@app.post("/chores")
+async def create_chore(chore: Chore) -> Chore:
+    DB.add_chore(chore)
+    return chore
+
+
+@app.post("/assign")
+async def assign_chore(assignment: Assignment) -> Assignment:
+    DB.add_assignment(assignment)
+    return assignment
+
+
+@app.post("/complete")
+async def complete_chore(assignment: Assignment) -> Assignment:
+    # Mark as completed (simplified)
+    assignment.status = "completed"
+    DB.add_assignment(assignment)
+    return assignment
+
+
+@app.post("/approve")
+async def approve_chore(assignment: Assignment) -> Assignment:
+    assignment.status = "approved"
+    DB.add_assignment(assignment)
+    # award points
+    chore = DB.chores.get(assignment.choreId)
+    if chore:
+        DB.add_ledger_entry(PointLedgerEntry(userId=assignment.childId, delta=chore.points, reason=f"Chore {chore.title}"))
+    return assignment
+
+
+@app.get("/kids/{child_id}/points")
+async def get_points(child_id: int) -> dict:
+    return {"points": DB.get_points(child_id)}
+
+
+@app.post("/rewards")
+async def create_reward(reward: Reward) -> Reward:
+    DB.add_reward(reward)
+    return reward
+
+
+@app.post("/redeem")
+async def redeem_reward(child_id: int, reward_id: int) -> dict:
+    reward = DB.rewards.get(reward_id)
+    if not reward:
+        return {"status": "not_found"}
+    points = DB.get_points(child_id)
+    if points >= reward.cost:
+        DB.add_ledger_entry(PointLedgerEntry(userId=child_id, delta=-reward.cost, reason=f"Redeemed {reward.name}"))
+        return {"status": "approved"}
+    return {"status": "insufficient_points"}

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+from pydantic import BaseModel
+from typing import Optional, List
+
+
+class User(BaseModel):
+    id: int
+    name: str
+    role: str  # 'parent' or 'child'
+    avatar: Optional[str] = None
+
+
+class Chore(BaseModel):
+    id: int
+    title: str
+    description: Optional[str] = None
+    points: int = 0
+    required: bool = False
+    schedule: Optional[str] = None  # e.g. 'daily', 'weekly'
+
+
+class Assignment(BaseModel):
+    childId: int
+    choreId: int
+    status: str = "pending"  # pending, completed, approved
+    dueDate: Optional[str] = None
+
+
+class Reward(BaseModel):
+    id: int
+    name: str
+    cost: int
+    description: Optional[str] = None
+
+
+class PointLedgerEntry(BaseModel):
+    userId: int
+    delta: int
+    reason: str

--- a/backend/storage.py
+++ b/backend/storage.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+from typing import Dict, List
+from .models import User, Chore, Assignment, Reward, PointLedgerEntry
+
+
+class InMemoryDB:
+    def __init__(self):
+        self.users: Dict[int, User] = {}
+        self.chores: Dict[int, Chore] = {}
+        self.assignments: List[Assignment] = []
+        self.rewards: Dict[int, Reward] = {}
+        self.ledger: List[PointLedgerEntry] = []
+
+    def add_user(self, user: User) -> None:
+        self.users[user.id] = user
+
+    def add_chore(self, chore: Chore) -> None:
+        self.chores[chore.id] = chore
+
+    def add_assignment(self, assignment: Assignment) -> None:
+        self.assignments.append(assignment)
+
+    def add_reward(self, reward: Reward) -> None:
+        self.rewards[reward.id] = reward
+
+    def add_ledger_entry(self, entry: PointLedgerEntry) -> None:
+        self.ledger.append(entry)
+
+    def get_points(self, user_id: int) -> int:
+        return sum(e.delta for e in self.ledger if e.userId == user_id)
+
+DB = InMemoryDB()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "chores"
+version = "0.1.0"
+requires-python = ">=3.8"
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "pydantic",
+    "pytest",
+    "httpx",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+from backend.main import app
+
+client = TestClient(app)
+
+def test_create_and_assign_and_approve():
+    chore = {"id": 1, "title": "Dishes", "points": 5}
+    res = client.post("/chores", json=chore)
+    assert res.status_code == 200
+
+    assignment = {"childId": 1, "choreId": 1}
+    res = client.post("/assign", json=assignment)
+    assert res.status_code == 200
+
+    res = client.post("/approve", json=assignment)
+    assert res.status_code == 200
+
+    res = client.get("/kids/1/points")
+    assert res.json()["points"] == 5


### PR DESCRIPTION
## Summary
- scaffold Python FastAPI backend with endpoints for chores, assignments, rewards, and point totals
- add in-memory storage and pydantic models
- include pytest-based test for basic chore approval flow

## Testing
- `pytest` *(fails: No module named 'fastapi')*
- `pip install fastapi uvicorn pydantic pytest httpx` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_b_68ac8edeff10832e86d5d5df724da2e9